### PR TITLE
(Update twine-cert.txt) BVC-2721 - QR-Code scannen - missing notification

### DIFF
--- a/twine-cert.txt
+++ b/twine-cert.txt
@@ -308,6 +308,10 @@
     de = Schließen
     en = Close
 
+[accessibility_scan_dialog_camera_access_announce]
+    de = Die Ansicht "Kamerazugriff benötigt" wurde geöffnet 
+    en = The view "Camera access needed" has been opened 
+
 [accessibility_scan_camera_announce]
     de = Kamera-Ansicht wurde geöffnet
     en = Camera has been opened


### PR DESCRIPTION
BVC-2721 - Changed accessibility key: 
[accessibility_scan_success_announce]
    de = Zertifikat von %@ wurde erfolgreich hinzugefügt
    en = Certificate of %@ was added successfully