### PR TITLE
(CovPassCheck) BVC-2866 - New names for keys "Update rule set"

### DIFF
--- a/twine-validator.txt
+++ b/twine-validator.txt
@@ -521,7 +521,43 @@
 [accessibility_app_information_open_source_label_back]
     de = Zurück
     en = Back
+       
+[app_information_title_update]
+    de = Prüfregeln aktualisieren
+    en = Update rule set
+    
+[app_information_message_update]
+    de = Zur Überprüfung eingescannter Zertifikate benötigt die App aktuelle Listen der vertrauenswürdigen Zertifikatsaussteller und der momentan in Deutschland geltenden Corona-Regeln.\n\nDiese Listen aktualisieren sich täglich automatisch. Sie können hier auch jederzeit eine manuelle Aktualisierung vornehmen. 
+    en = To verify scanned certificates, the app requires up-to-date lists of trusted certificate issuers as well as the current Corona rules in Germany.\n\nThese lists are updated automatically on a daily basis. You can also manually update them here at any time. 
+    
+[app_information_message_update_note]
+    de = Letztes Update
+    en = Most recent update
 
+[app_information_message_update_pattern]
+    de = Letztes Update: %@
+    en = Most recent update: %@
+
+[app_information_message_update_certificates]
+    de = Liste der Zertifikatsaussteller: %@
+    en = List of certificate issuers: %@
+
+[app_information_message_update_rules]
+    de = Prüfregeln: %@
+    en = Rule set: %@
+
+[app_information_message_update_button]
+    de = Aktualisieren
+    en = Update
+
+[accessibility_app_information_update_back]
+    de = Zurück
+    en = Back
+    
+[accessibility_app_information_title_update]
+    de = Die Ansicht "Prüfregeln aktualisieren" wurde geöffnet
+    en = The view "Update rule set" has been opened  
+    
 [app_information_version_label]
     de = Version %@
     en = Version %@


### PR DESCRIPTION
Changed the name and place of the keys for uniformity with the covpass app