### PR TITLE
(CovPass) keys removed: "Revoked certificates"

### DIFF
--- a/twine-cert.txt
+++ b/twine-cert.txt
@@ -147,26 +147,6 @@
     de = OK
     en = OK
 
-[certificate_will_be_revoked_notification_icon_new]
-    de = Neu
-    en = New
-
-[certificate_will_be_revoked_notification_title]
-    de = Ihr Zertifikat wird zum 11.11.2021 gesperrt
-    en = Your certificate will be revoked by 11.11.2021
-
-[certificate_will_be_revoked_notification_message]
-    de = Aus Sicherheitsgründen müssen alle Zertifikate der von Ihnen besuchten Apotheke neu ausgestellt werden.\n\nIhr Zertifikat wird am 11.11.2021 gesperrt. Sie können sich unter Vorlage Ihres gelben Impfpasses und eines Lichtbildausweises in Ihrer Apotheke kostenfrei ein neues Impfzertifikat ausstellen lassen.
-    en = For security reasons, all certificates coming from the pharmacy you visited must be reissued.\n\nYour certificate will be revoked on 11/11/2021. You can have a new vaccination certificate issued free of charge at your pharmacy by presenting your yellow vaccination certificate and a photo ID.
-
-[certificate_will_be_revoked_notification_button]
-    de = OK
-    en = OK
-
-[accessibility_certificate_will_be_revoked_info_announce]
-    de = Die Ansicht "Zertifikat wird gesperrt" wurde geöffnet
-    en = The view "Certificate will be revoked" has been opened
-
 
 [[start screen]]
 [accessibility_vaccination_start_screen_label_information]


### PR DESCRIPTION
I have removed the keys to "revoked certificates" again, since they are no longer needed. 