### PR TITLE
Github Action: Validate twine files

### DIFF
--- a/.github/workflows/validate-twine.yml
+++ b/.github/workflows/validate-twine.yml
@@ -1,7 +1,7 @@
 name: Validate twine files
 on: [push]
 jobs:
-  install-and-test:
+  validate:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/validate-twine.yml
+++ b/.github/workflows/validate-twine.yml
@@ -1,0 +1,17 @@
+name: Validate twine files
+on: [push]
+jobs:
+  install-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.6
+      - name: Install twine
+        run: |
+          gem install twine
+      - name: Validate files
+        run: |
+          twine validate-twine-file twine-cert.txt
+          twine validate-twine-file twine-validator.txt


### PR DESCRIPTION
This PR adds a Github Action that validates the twine files on each commit to prevent unwanted parsing errors.

Not sure if Github Actions are enabled but the Maintainer will know this.